### PR TITLE
feat: 🎸 access version from node env

### DIFF
--- a/libs/nx-release/README.md
+++ b/libs/nx-release/README.md
@@ -22,9 +22,10 @@ Maybe you have a more sophisticated setup and therefore your library is in a dif
 ## update-version
 This executor updates the `package.json` version in the specified library. The executor **requires** the following config options:
 
-- **version**: the new version
 - **libName**: the name of the library. The path will be constructed in the following way: `libs/${libName}/package.json`
 
 if your library is in a different folder, you can always optionally specify the library path:
 
 - **libPath**: optional library path. for example: `libs/my-domain`
+
+**The update-version executor expects a VERSION env variable to be present**

--- a/libs/nx-release/src/executors/update-version/executor.spec.ts
+++ b/libs/nx-release/src/executors/update-version/executor.spec.ts
@@ -2,14 +2,15 @@ import * as replaceJsonProp from 'replace-json-property';
 
 import { ReplaceVersionExecutorSchema } from './schema';
 import executor from './executor';
+import * as process from "process";
 
 describe('ReplaceVersion Executor', () => {
 
   it('should replace the version with in the default path if no path was provided', async () => {
     const version = '2.0.0';
     const libName = 'foo';
+    process.env.VERSION = version;
     const options: ReplaceVersionExecutorSchema = {
-      version,
       libName
     };
     const expectedPath = `libs/${libName}/package.json`;
@@ -27,8 +28,9 @@ describe('ReplaceVersion Executor', () => {
     const version = '2.0.0';
     const libName = 'foo';
     const libPath = './libs/my-domain/test';
+    process.env.VERSION = version;
+
     const options: ReplaceVersionExecutorSchema = {
-      version,
       libName,
       libPath
     };

--- a/libs/nx-release/src/executors/update-version/executor.ts
+++ b/libs/nx-release/src/executors/update-version/executor.ts
@@ -1,16 +1,17 @@
 import { ReplaceVersionExecutorSchema } from './schema';
 import {replace} from 'replace-json-property';
+import * as process from "process";
 
 export default async function runExecutor(
   options: ReplaceVersionExecutorSchema
 ) {
-  const {libName, libPath, version} = options;
+  const {libName, libPath} = options;
 
   const packageJsonPath = libPath ?
     `${libPath}/${libName}/package.json` :
     `libs/${libName}/package.json`
 
-  replace(packageJsonPath, 'version', version);
+  replace(packageJsonPath, 'version', process.env.VERSION);
 
   return {
     success: true,

--- a/libs/nx-release/src/executors/update-version/schema.d.ts
+++ b/libs/nx-release/src/executors/update-version/schema.d.ts
@@ -1,5 +1,4 @@
 export interface ReplaceVersionExecutorSchema {
   libPath?: string;
-  libName: string
-  version: string
+  libName: string;
 }

--- a/libs/nx-release/src/executors/update-version/schema.json
+++ b/libs/nx-release/src/executors/update-version/schema.json
@@ -20,15 +20,7 @@
         "$source": "argv",
         "index": 0
       }
-    },
-    "version": {
-      "type": "string",
-      "description": "The new version",
-      "$default": {
-        "$source": "argv",
-        "index": 0
-      }
     }
   },
-  "required": ["libName", "version"]
+  "required": ["libName"]
 }


### PR DESCRIPTION
BREAKING CHANGE: 🧨 version input is no longer supported