### PR TITLE
feat(npm-publish): do not override current .npmrc file

### DIFF
--- a/libs/nx-release/src/executors/npm-publish/executor.ts
+++ b/libs/nx-release/src/executors/npm-publish/executor.ts
@@ -11,7 +11,7 @@ export default async function runExecutor(options: NpmPublishExecutorSchema,
   const sourceRoot = `./dist/${getRoot(context)}`;
   const registry: string = process.env.NPM_REGISTRY || 'registry.npmjs.org'
   execSync(
-    `cd ${sourceRoot} && echo '//${registry}/:_authToken=${process.env.NPM_TOKEN}' > .npmrc && npm publish`
+    `cd ${sourceRoot} && echo '//${registry}/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish`
   );
   return {
     success: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nx-release/source",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nx-release/source",
-      "version": "3.1.6",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@nx/devkit": "16.5.0",


### PR DESCRIPTION
Hello!

As stated in my previous PR's latest comment, I have made the update to take into account the fact that the current .npmrc file content should not be overwritten when trying to run release commands.

I remain at your disposal if you want to discuss this feature.