### PR TITLE
feat: npm publish uses channel for distribution tags

### DIFF
--- a/libs/nx-release/src/executors/npm-publish/executor.spec.ts
+++ b/libs/nx-release/src/executors/npm-publish/executor.spec.ts
@@ -1,6 +1,6 @@
-import * as child_process from 'child_process';
+import * as child_process from "child_process";
 
-import * as projectHelpers from '../helpers/projects.helpers';
+import * as projectHelpers from "../helpers/projects.helpers";
 
 import executor from './executor';
 
@@ -17,7 +17,8 @@ describe('NpmPublish Executor', () => {
 
   it('should execSync with a default libPath if no libPath was provided', async () => {
     const mockRoot = 'libs/my-domain/foo';
-    const context = {} as any;
+    const context = {
+    } as any;
 
     /* eslint-disable */
     jest.spyOn(child_process, 'execSync').mockImplementation((() => {}) as any);
@@ -33,7 +34,8 @@ describe('NpmPublish Executor', () => {
 
   it('should execSync with a specific npm registry if provided with one', async () => {
     const mockRoot = 'libs/my-domain/foo';
-    const context = {} as any;
+    const context = {
+    } as any;
     const registry = 'specific-npm-registry.org';
     process.env = Object.assign(process.env, { NPM_REGISTRY: registry });
 
@@ -51,7 +53,8 @@ describe('NpmPublish Executor', () => {
 
   it('should execSync with a specific npm channel if provided with one', async () => {
     const mockRoot = 'libs/my-domain/foo';
-    const context = {} as any;
+    const context = {
+    } as any;
     const channel = 'beta';
     process.env = Object.assign(process.env, { CHANNEL: channel });
 

--- a/libs/nx-release/src/executors/npm-publish/executor.spec.ts
+++ b/libs/nx-release/src/executors/npm-publish/executor.spec.ts
@@ -1,6 +1,6 @@
-import * as child_process from "child_process";
+import * as child_process from 'child_process';
 
-import * as projectHelpers from "../helpers/projects.helpers";
+import * as projectHelpers from '../helpers/projects.helpers';
 
 import executor from './executor';
 
@@ -17,15 +17,14 @@ describe('NpmPublish Executor', () => {
 
   it('should execSync with a default libPath if no libPath was provided', async () => {
     const mockRoot = 'libs/my-domain/foo';
-    const context = {
-    } as any;
+    const context = {} as any;
 
     /* eslint-disable */
     jest.spyOn(child_process, 'execSync').mockImplementation((() => {}) as any);
     /* eslint-disable */
     jest.spyOn(projectHelpers, 'getRoot').mockReturnValue(mockRoot);
 
-    const expectedCommand = `cd ./dist/${mockRoot} && echo '//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish`
+    const expectedCommand = `cd ./dist/${mockRoot} && echo '//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=latest`;
     const output = await executor({}, context);
 
     expect(child_process.execSync).toHaveBeenCalledWith(expectedCommand);
@@ -34,8 +33,7 @@ describe('NpmPublish Executor', () => {
 
   it('should execSync with a specific npm registry if provided with one', async () => {
     const mockRoot = 'libs/my-domain/foo';
-    const context = {
-    } as any;
+    const context = {} as any;
     const registry = 'specific-npm-registry.org';
     process.env = Object.assign(process.env, { NPM_REGISTRY: registry });
 
@@ -44,7 +42,25 @@ describe('NpmPublish Executor', () => {
     /* eslint-disable */
     jest.spyOn(projectHelpers, 'getRoot').mockReturnValue(mockRoot);
 
-    const expectedCommand = `cd ./dist/${mockRoot} && echo '//${registry}/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish`
+    const expectedCommand = `cd ./dist/${mockRoot} && echo '//${registry}/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=latest`;
+    const output = await executor({}, context);
+
+    expect(child_process.execSync).toHaveBeenCalledWith(expectedCommand);
+    expect(output.success).toBe(true);
+  });
+
+  it('should execSync with a specific npm channel if provided with one', async () => {
+    const mockRoot = 'libs/my-domain/foo';
+    const context = {} as any;
+    const channel = 'beta';
+    process.env = Object.assign(process.env, { CHANNEL: channel });
+
+    /* eslint-disable */
+    jest.spyOn(child_process, 'execSync').mockImplementation((() => {}) as any);
+    /* eslint-disable */
+    jest.spyOn(projectHelpers, 'getRoot').mockReturnValue(mockRoot);
+
+    const expectedCommand = `cd ./dist/${mockRoot} && echo '//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=${channel}`;
     const output = await executor({}, context);
 
     expect(child_process.execSync).toHaveBeenCalledWith(expectedCommand);

--- a/libs/nx-release/src/executors/npm-publish/executor.spec.ts
+++ b/libs/nx-release/src/executors/npm-publish/executor.spec.ts
@@ -25,7 +25,7 @@ describe('NpmPublish Executor', () => {
     /* eslint-disable */
     jest.spyOn(projectHelpers, 'getRoot').mockReturnValue(mockRoot);
 
-    const expectedCommand = `cd ./dist/${mockRoot} && echo '//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=latest`;
+    const expectedCommand = `cd ./dist/${mockRoot} && echo '//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=latest`
     const output = await executor({}, context);
 
     expect(child_process.execSync).toHaveBeenCalledWith(expectedCommand);
@@ -44,7 +44,7 @@ describe('NpmPublish Executor', () => {
     /* eslint-disable */
     jest.spyOn(projectHelpers, 'getRoot').mockReturnValue(mockRoot);
 
-    const expectedCommand = `cd ./dist/${mockRoot} && echo '//${registry}/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=latest`;
+    const expectedCommand = `cd ./dist/${mockRoot} && echo '//${registry}/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=latest`
     const output = await executor({}, context);
 
     expect(child_process.execSync).toHaveBeenCalledWith(expectedCommand);
@@ -63,7 +63,7 @@ describe('NpmPublish Executor', () => {
     /* eslint-disable */
     jest.spyOn(projectHelpers, 'getRoot').mockReturnValue(mockRoot);
 
-    const expectedCommand = `cd ./dist/${mockRoot} && echo '//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=${channel}`;
+    const expectedCommand = `cd ./dist/${mockRoot} && echo '//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=${channel}`
     const output = await executor({}, context);
 
     expect(child_process.execSync).toHaveBeenCalledWith(expectedCommand);

--- a/libs/nx-release/src/executors/npm-publish/executor.ts
+++ b/libs/nx-release/src/executors/npm-publish/executor.ts
@@ -1,17 +1,19 @@
-import {execSync} from 'child_process';
-import {ExecutorContext} from "@nx/devkit";
+import { execSync } from 'child_process';
+import { ExecutorContext } from '@nx/devkit';
 
-import {getRoot} from "../helpers/projects.helpers";
+import { getRoot } from '../helpers/projects.helpers';
 
-import {NpmPublishExecutorSchema} from './schema';
+import { NpmPublishExecutorSchema } from './schema';
 
-export default async function runExecutor(options: NpmPublishExecutorSchema,
-                                          context: ExecutorContext
+export default async function runExecutor(
+  options: NpmPublishExecutorSchema,
+  context: ExecutorContext
 ) {
   const sourceRoot = `./dist/${getRoot(context)}`;
-  const registry: string = process.env.NPM_REGISTRY || 'registry.npmjs.org'
+  const registry: string = process.env.NPM_REGISTRY || 'registry.npmjs.org';
+  const channel: string = process.env.CHANNEL || 'latest';
   execSync(
-    `cd ${sourceRoot} && echo '//${registry}/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish`
+    `cd ${sourceRoot} && echo '//${registry}/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=${channel}`
   );
   return {
     success: true,

--- a/libs/nx-release/src/executors/npm-publish/executor.ts
+++ b/libs/nx-release/src/executors/npm-publish/executor.ts
@@ -6,11 +6,11 @@ import {getRoot} from "../helpers/projects.helpers";
 import {NpmPublishExecutorSchema} from './schema';
 
 export default async function runExecutor(options: NpmPublishExecutorSchema,
-  context: ExecutorContext
+                                          context: ExecutorContext
 ) {
   const sourceRoot = `./dist/${getRoot(context)}`;
-  const registry: string = process.env.NPM_REGISTRY || 'registry.npmjs.org';
-  const channel: string = process.env.CHANNEL || 'latest';
+  const registry: string = process.env.NPM_REGISTRY || 'registry.npmjs.org'
+  const channel: string = process.env.CHANNEL || 'latest'
   execSync(
     `cd ${sourceRoot} && echo '//${registry}/:_authToken=${process.env.NPM_TOKEN}' >> .npmrc && npm publish --tag=${channel}`
   );

--- a/libs/nx-release/src/executors/npm-publish/executor.ts
+++ b/libs/nx-release/src/executors/npm-publish/executor.ts
@@ -1,12 +1,11 @@
-import { execSync } from 'child_process';
-import { ExecutorContext } from '@nx/devkit';
+import {execSync} from 'child_process';
+import {ExecutorContext} from "@nx/devkit";
 
-import { getRoot } from '../helpers/projects.helpers';
+import {getRoot} from "../helpers/projects.helpers";
 
-import { NpmPublishExecutorSchema } from './schema';
+import {NpmPublishExecutorSchema} from './schema';
 
-export default async function runExecutor(
-  options: NpmPublishExecutorSchema,
+export default async function runExecutor(options: NpmPublishExecutorSchema,
   context: ExecutorContext
 ) {
   const sourceRoot = `./dist/${getRoot(context)}`;


### PR DESCRIPTION
With this PR, providing CHANNEL environment variable is going to allow setting a distribution tag for the package. The variable is optional and defaults to 'latest' which is the current behavior. Please consider introducing the change so its possible to customize the distribution tag :)